### PR TITLE
Fix Lambda routing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,18 @@ defaults:
     shell: bash
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+      - run: make up test
+
   push:
     name: Bump tag
+    needs: [test]
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     outputs:

--- a/delegator/main.go
+++ b/delegator/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-var rPath = regexp.MustCompile("/2015-03-31/functions/lpa-uid-([a-z-]+)-local/invocations")
+var rPath = regexp.MustCompile("/2015-03-31/functions/lpa-uid-([a-z-]+)-local-eu-west-1/invocations")
 
 type ApiGatewayResponse struct {
 	IsBase64Encoded bool        `json:"isBase64Encoded"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     entrypoint: /var/task/main
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:latest
     depends_on: [delegator]
     ports:
       - "4566:4566"
@@ -32,6 +32,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
     environment:
       DEFAULT_REGION: eu-west-1
+      PROVIDER_OVERRIDE_LAMBDA: legacy
       LAMBDA_FORWARD_URL: http://delegator:8080
       DOCKER_HOST: unix:///var/run/docker.sock
     healthcheck:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -61,6 +61,7 @@ paths:
                   id:
                     type: string
                     pattern: "MTEST-([346789QWERTYUPADFGHJKLXCVBNM]{4})-([346789QWERTYUPADFGHJKLXCVBNM]{4})-([346789QWERTYUPADFGHJKLXCVBNM]{4})"
+                    example: MTEST-789Q-P4DF-4UX3
                 additionalProperties: false
         "400":
           description: Invalid request


### PR DESCRIPTION
- Use `PROVIDER_OVERRIDE_LAMBDA=legacy` so we can continue using `LAMBDA_FORWARD_URL`
- Fix the path regex since the function name now contains the region too
- Unrelated, but add an example to the createCase:201 response to easily build mock servers

Add `make test` to pipeline for a bit of loose verification

#patch